### PR TITLE
add uid duplicates_in_dataset validation #3

### DIFF
--- a/src/validator/main.py
+++ b/src/validator/main.py
@@ -8,6 +8,7 @@ Run from the terminal to see the generated output.
 import sys
 
 import pandas as pd
+from check_functions import is_unique_column
 from pandera.errors import SchemaErrors
 from schema import sblar_schema
 
@@ -29,6 +30,11 @@ def run_validation_on_df(df: pd.DataFrame) -> None:
     print("")
 
     try:
+        uid_uniqueness_check = is_unique_column(df.uid)
+        if uid_uniqueness_check[0] == False:
+            print(f"Validation uid.duplicates_in_dataset failed")
+            print(uid_uniqueness_check[1])
+            print("")
         sblar_schema(df, lazy=True)
     except SchemaErrors as errors:
         for error in errors.schema_errors:
@@ -57,6 +63,6 @@ if __name__ == "__main__":
         csv_path = sys.argv[1]
     except IndexError:
         raise ValueError("csv_path arg not provided")
-    
+
     df = csv_to_df(csv_path)
     run_validation_on_df(df)


### PR DESCRIPTION
add uid's [duplicates_in_dataset](https://content.consumerfinance.gov/data-research/small-business-lending/filing-instructions-guide/2024-guide/#4.3.1) validation.

This validation is not using Pandera built-in check functionality. 

Basically, we're creating and calling our own validation.  This validation returns similar result to pandera's check but in more simpler format.  This custom/manual validation returns list of indexes and the validation result (bool: True/False).  

For example:: If there is a duplicate UID on index 0 and 1  (Row 2 and 3 in CSV file) then this validation returns:
<img width="1143" alt="Screenshot 2023-07-28 at 11 34 26 AM" src="https://github.com/cfpb/regtech-data-validator/assets/28935959/b96df194-a469-42a4-8ca6-92587c4fcce2">

Note:  need to add unit tests if this option is selected

