### PR TITLE
add black formatter extension to dev-container json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
     "vscode": {
       "extensions": [
         "ms-python.python",
+        "ms-python.black-formatter",
         "donjayamanne.python-extension-pack",
         "ms-python.isort",
         "njpwerner.autodocstring",
@@ -16,6 +17,10 @@
         "littlefoxteam.vscode-python-test-adapter"
       ],
       "settings": {
+        "[python]": {
+          "editor.defaultFormatter": "ms-python.black-formatter",
+          "editor.formatOnSave": true
+        },
         "files.exclude": {
           "**/.git": true,
           "**/.svn": true,
@@ -35,7 +40,7 @@
         ],
         "editor.tabSize": 4,
         "editor.formatOnSave": true,
-        "python.formatting.provider": "black",
+        "python.formatting.provider": "none",
         "python.envFile": "${workspaceFolder}/.env",
         "editor.codeActionsOnSave": {
           "source.organizeImports": true


### PR DESCRIPTION
Currently, we have to install black-formatter manually after reloading/rebuilding dev-container, and occasionally, we forget to re-install this extension that caused formatting issue.

This update will install black-formatter automatically when rebuilding/creating dev-container.