### PR TITLE
update deprecated pandas function

### DIFF
--- a/src/tests/test_global_data.py
+++ b/src/tests/test_global_data.py
@@ -1,0 +1,25 @@
+import pytest
+
+from validator import global_data
+
+
+class TestGlobalData:
+    def test_valid_naics_codes(self):
+        global_data.read_naics_codes()
+        assert len(global_data.naics_codes) == 96
+
+    def test_valid_geoids(self):
+        global_data.read_geoids()
+        assert len(global_data.census_geoids) == 87275
+
+    def test_invalid_naics_file(self):
+        failed_fpath = "./data/naics/processed/2022_codes.csv1"
+        with pytest.raises(Exception) as exc:
+            global_data.read_naics_codes(failed_fpath)
+        assert exc.type == FileNotFoundError
+
+    def test_invalid_geoids_file(self):
+        failed_fpath = "./data/census/processed/Census2022.processed.csv2"
+        with pytest.raises(Exception) as exc:
+            global_data.read_geoids(failed_fpath)
+        assert exc.type == FileNotFoundError

--- a/src/validator/global_data.py
+++ b/src/validator/global_data.py
@@ -14,23 +14,23 @@ naics_codes = {}
 census_geoids = {}
 
 
-def read_naics_codes():
+def read_naics_codes(csv_path: str = NAICS_CSV_PATH):
     """
     read NAICS CSV file with this format: (code, description)
     and populate global value: naics_codes
     """
     naics_codes.clear()
-    df = pd.read_csv(NAICS_CSV_PATH, dtype=str, na_filter=False)
+    df = pd.read_csv(csv_path, dtype=str, na_filter=False)
     for _, row in df.iterrows():
-        naics_codes.update({row[0]: row[1]})
+        naics_codes.update({row.iloc[0]: row.iloc[1]})
 
 
-def read_geoids():
+def read_geoids(csv_path: str = CENSUS_PROCESSED_CSV_PATH):
     """
     read geoids CSV file with this format: (code)
     and populate global value: census_geoids
     """
     census_geoids.clear()
-    df = pd.read_csv(CENSUS_PROCESSED_CSV_PATH, dtype=str, na_filter=False)
+    df = pd.read_csv(csv_path, dtype=str, na_filter=False)
     for _, row in df.iterrows():
-        census_geoids.update({row[0]: None})
+        census_geoids.update({row.iloc[0]: None})


### PR DESCRIPTION
closed #48 

Update:
- update deprecated pandas function to fix warning.  
- update global_data function to make it easier for unit testing.
- add global_data unit tests
