### PR TITLE
68 correct validation description errors

### DIFF
--- a/regtech_data_validator/phase_validations.py
+++ b/regtech_data_validator/phase_validations.py
@@ -673,7 +673,7 @@ def get_phase_1_and_2_validations_for_lei(context: dict[str, str] | None = None)
                     description=(
                         "When 'action taken' equals 1 (originated) or 2 (approved but not accepted), the following"
                         " fields all must not be blank:\n- 'Total origination charges'\n- 'Amount of total broker"
-                        " fees'\n- 'Initial annual charges'\nAnd the following fields must not equal 999 (not"
+                        " fees'\n- 'Initial annual charges'\nand the following fields must not equal 999 (not"
                         " applicable):\n- 'Prepayment penalty could be imposed'\n- 'Prepayment penalty exists'"
                     ),
                     severity=Severity.ERROR,


### PR DESCRIPTION
These are all changes to make our python code consistent with the CVS located at https://raw.githubusercontent.com/cfpb/sbl-content/main/fig-files/validation-spec/2024-validations.csv

This goes hand in hand with issue #65 

Of note is the addition of W0680, which checks the Census GEO id against the census CSV.  

Majority of the changes involved missing spaces, copy/paste errors, etc.  

The updates to this file are still in progress as there are 4 errors (E0940, E1120, E1300, E1480) that have descriptions that Chynna and Shomari are looking into to verify if the CSV is correct. So this PR is simply to get a head start.