### PR TITLE
Added versions to the ruff and black linter actions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,8 +10,11 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --diff --verbose"
+          version: 24.1.1
   ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1
+        with:
+            version: 0.1.4

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,7 +19,7 @@ jobs:
           poetry install --only linters
       - name: Run black
         run: |
-          poetry run black .
+          poetry run black --check .
   ruff:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -17,11 +17,6 @@ jobs:
           pip install poetry
           poetry config virtualenvs.create false
           poetry install --only linters
-      - name: Cache venv 
-        uses: actions/cache@v4
-        with:
-          path: ./.venv
-          key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
       - name: Run black
         run: |
           poetry run black --check .
@@ -39,11 +34,6 @@ jobs:
           pip install poetry
           poetry config virtualenvs.create false
           poetry install --only linters
-      - name: Cache venv 
-        uses: actions/cache@v4
-        with:
-          path: ./.venv
-          key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
       - name: Run ruff
         run: |
           poetry run ruff .

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -17,6 +17,11 @@ jobs:
           pip install poetry
           poetry config virtualenvs.create false
           poetry install --only linters
+      - name: Cache venv 
+        uses: actions/cache@v4
+        with:
+          path: ./.venv
+          key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
       - name: Run black
         run: |
           poetry run black --check .
@@ -34,6 +39,11 @@ jobs:
           pip install poetry
           poetry config virtualenvs.create false
           poetry install --only linters
+      - name: Cache venv 
+        uses: actions/cache@v4
+        with:
+          path: ./.venv
+          key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
       - name: Run ruff
         run: |
           poetry run ruff .

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,15 +6,34 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: psf/black@stable
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
         with:
-          options: "--check --diff --verbose"
-          version: 24.1.1
+          python-version: 3.11
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry config virtualenvs.create false
+          poetry install --only linters
+      - name: Run black
+        run: |
+          poetry run black .
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
         with:
-            version: 0.1.4
+          python-version: 3.11
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry config virtualenvs.create false
+          poetry install --only linters
+      - name: Run ruff
+        run: |
+          poetry run ruff .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ pandera = "^0.18.0"
 [tool.poetry.group.dev.dependencies]
 pytest = "8.0.0"
 pytest-cov = "4.1.0"
-black = "24.1.1"
-ruff = "0.1.15"
 
 [tool.poetry.group.data.dependencies]
 openpyxl = "^3.1.2"
@@ -26,6 +24,11 @@ openpyxl = "^3.1.2"
 [tool.poetry.group.cli.dependencies]
 tabulate = "^0.9.0"
 typer = "^0.9.0"
+
+
+[tool.poetry.group.linters.dependencies]
+black = "24.1.1"
+ruff = "0.1.15"
 
 [tool.poetry.scripts]
 cfpb-val = 'regtech_data_validator.cli:app'

--- a/regtech_data_validator/cli.py
+++ b/regtech_data_validator/cli.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import StrEnum
-import json, datatime
+import json
 from pathlib import Path
 from typing import Annotated, Optional
 
@@ -18,6 +18,7 @@ app = typer.Typer(no_args_is_help=True, pretty_exceptions_enable=False)
 class KeyValueOpt:
     key: str
     value: str
+
 
 def parse_key_value(kv_str: str) -> KeyValueOpt:
     split_str = kv_str.split('=')
@@ -62,7 +63,11 @@ def df_to_json(df: pd.DataFrame) -> str:
         v_head = v_id_df.iloc[0]
 
         finding_json = {
-            'validation': {'id': v_id_idx,'name': v_head.at['validation_name'],'description': v_head.at['validation_desc'],'severity': v_head.at['validation_severity'],
+            'validation': {
+                'id': v_id_idx,
+                'name': v_head.at['validation_name'],
+                'description': v_head.at['validation_desc'],
+                'severity': v_head.at['validation_severity'],
             },
             'records': [],
         }

--- a/regtech_data_validator/cli.py
+++ b/regtech_data_validator/cli.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import StrEnum
-import json
+import json, datatime
 from pathlib import Path
 from typing import Annotated, Optional
 
@@ -18,7 +18,6 @@ app = typer.Typer(no_args_is_help=True, pretty_exceptions_enable=False)
 class KeyValueOpt:
     key: str
     value: str
-
 
 def parse_key_value(kv_str: str) -> KeyValueOpt:
     split_str = kv_str.split('=')
@@ -63,11 +62,7 @@ def df_to_json(df: pd.DataFrame) -> str:
         v_head = v_id_df.iloc[0]
 
         finding_json = {
-            'validation': {
-                'id': v_id_idx,
-                'name': v_head.at['validation_name'],
-                'description': v_head.at['validation_desc'],
-                'severity': v_head.at['validation_severity'],
+            'validation': {'id': v_id_idx,'name': v_head.at['validation_name'],'description': v_head.at['validation_desc'],'severity': v_head.at['validation_severity'],
             },
             'records': [],
         }


### PR DESCRIPTION
Closes #89 

Added versions to the linter actions.  Since the pyproject.toml specifies distinct versions for each (instead of say ^24.1.0), I put the version equal to what is in the toml.  Note that, as in the other stories referenced, the black linter supports the concept of capability versions.  We're just not using itwith:
          version: 0.0.278here.