### PR TITLE
Updated df_to_download to create an empty csv with headers

### DIFF
--- a/src/regtech_data_validator/cli.py
+++ b/src/regtech_data_validator/cli.py
@@ -91,7 +91,8 @@ def validate(
     status = 'SUCCESS'
     no_of_findings = 0
 
-    if not is_valid:
+    #if not is_valid:
+    if True:
         status = 'FAILURE'
         no_of_findings = len(findings_df.index.unique())
 

--- a/src/regtech_data_validator/cli.py
+++ b/src/regtech_data_validator/cli.py
@@ -91,8 +91,7 @@ def validate(
     status = 'SUCCESS'
     no_of_findings = 0
 
-    #if not is_valid:
-    if True:
+    if not is_valid:
         status = 'FAILURE'
         no_of_findings = len(findings_df.index.unique())
 

--- a/src/regtech_data_validator/data_formatters.py
+++ b/src/regtech_data_validator/data_formatters.py
@@ -6,29 +6,30 @@ from tabulate import tabulate
 
 def df_to_download(df: pd.DataFrame) -> str:
     highest_field_count = 0
-    findings_group = df.reset_index().set_index(['validation_id', 'record_no', 'field_name'])
     full_csv = []
-    for v_id, v_id_df in findings_group.groupby(by='validation_id'):
-        v_head = v_id_df.iloc[0]
-        for record_no, rec_df in v_id_df.groupby(by='record_no'):
-            row_data = []
-            rec = rec_df.iloc[0]
-            row_data.append(v_head['validation_severity'])
-            row_data.append(v_id)
-            row_data.append(v_head['validation_name'])
-            row_data.append(str(record_no))
-            row_data.append(rec['uid'])
-            row_data.append(v_head['fig_link'])
-            row_data.append(f"\"{v_head['validation_desc']}\"")
+    if not df.empty:
+        findings_group = df.reset_index().set_index(['validation_id', 'record_no', 'field_name'])
+        for v_id, v_id_df in findings_group.groupby(by='validation_id'):
+            v_head = v_id_df.iloc[0]
+            for record_no, rec_df in v_id_df.groupby(by='record_no'):
+                row_data = []
+                rec = rec_df.iloc[0]
+                row_data.append(v_head['validation_severity'])
+                row_data.append(v_id)
+                row_data.append(v_head['validation_name'])
+                row_data.append(str(record_no))
+                row_data.append(rec['uid'])
+                row_data.append(v_head['fig_link'])
+                row_data.append(f"\"{v_head['validation_desc']}\"")
 
-            current_count = 0
-            for field_name, field_df in rec_df.groupby(by='field_name'):
-                field_data = field_df.iloc[0]
-                row_data.append(field_name)
-                row_data.append(field_data['field_value'])
-                current_count += 1
-            full_csv.append(",".join(row_data))
-        highest_field_count = current_count if current_count > highest_field_count else highest_field_count
+                current_count = 0
+                for field_name, field_df in rec_df.groupby(by='field_name'):
+                    field_data = field_df.iloc[0]
+                    row_data.append(field_name)
+                    row_data.append(field_data['field_value'])
+                    current_count += 1
+                full_csv.append(",".join(row_data))
+            highest_field_count = current_count if current_count > highest_field_count else highest_field_count
 
     field_headers = []
     for i in range(highest_field_count):

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -135,7 +135,7 @@ class TestOutputFormat:
         ).strip('\n')
         actual_output = df_to_download(self.input_df)
         assert actual_output == expected_output
-        
+
     def test_empty_download_csv(self):
         expected_output = dedent(
             """

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -135,3 +135,12 @@ class TestOutputFormat:
         ).strip('\n')
         actual_output = df_to_download(self.input_df)
         assert actual_output == expected_output
+        
+    def test_empty_download_csv(self):
+        expected_output = dedent(
+            """
+            validation_type,validation_id,validation_name,row,unique_identifier,fig_link,validation_description
+            """
+        ).strip('\n')
+        actual_output = df_to_download(pd.DataFrame())
+        assert actual_output == expected_output


### PR DESCRIPTION
Closes #135 

I did this so the filing-api will always have a report to upload.  There will be no confusion if someone looks in the S3, or tries to download a report.  The report will always be there, it's just a successfully validated submission that has no errors or warning will be empty (essentially like an empty json being stored in the submission object).

If we don't like this approach, I'll need to update the /report endpoint story to only call df_to_download if there are errors/warnings, and then on that /report endpoint GET, check that a report exists in the S3 first before trying to read it.  Right now the assumption is a report will always be there, even if empty.