### PR TITLE
Added comparison_helper that uses python eval to check value comaprisons

### DIFF
--- a/src/regtech_data_validator/check_functions.py
+++ b/src/regtech_data_validator/check_functions.py
@@ -39,6 +39,21 @@ def _check_blank_(value: str, check_result: bool, accept_blank: bool = False) ->
         return check_result
 
 
+def comparison_helper(value: str, sign: str, limit: str, accept_blank: bool = False) -> bool:
+    """
+    Used to first check if blank values are acceptable and returns corresponding boolean result.
+    Then, if actual value exists, uses python eval() to convert string to numerical values
+    and then evals again to use the passed in sign to compare the value to the limit.  This
+    ensures accurate comparison checks.
+    """
+    if accept_blank and not value.strip():
+        return True
+    elif not accept_blank and not value.strip():
+        return False
+    else:
+        return (bool)(eval(f"eval(value) {sign} eval(limit)"))
+
+
 def begins_with_same_lei(ulis: pd.Series) -> bool:
     """Verifies that only a single LEI prefixes the list of ULIs.
 
@@ -452,51 +467,15 @@ def is_valid_code(ct_value: str, accept_blank: bool = False, codes: dict = {}) -
 
 
 def is_greater_than_or_equal_to(value: str, min_value: str, accept_blank: bool = False) -> bool:
-    """
-    check if value is greater or equal to min_value or blank
-    If blank value check is not needed, use built-in 'greater_than_or_equal_to'
-
-    Args:
-        value (str): parsed value
-        min_value(str): minimum value
-        accept_blank (bool): accept blank value
-    Returns:
-        bool: true if blank or value is greater than or equal to min value
-    """
-    check_result = value >= min_value
-    return _check_blank_(value, check_result, accept_blank)
+    return comparison_helper(value, ">=", min_value, accept_blank)
 
 
 def is_greater_than(value: str, min_value: str, accept_blank: bool = False) -> bool:
-    """
-    check if value is greater than min_value or blank
-    If blank value check is not needed, use built-in 'greater_than'
-
-    Args:
-        value (str): parsed value
-        min_value(str): minimum value
-        accept_blank (bool): accept blank value
-    Returns:
-        bool: true if blank or value is greater than min value
-    """
-    check_result = value > min_value
-    return _check_blank_(value, check_result, accept_blank)
+    return comparison_helper(value, ">", min_value, accept_blank)
 
 
 def is_less_than(value: str, max_value: str, accept_blank: bool = False) -> bool:
-    """
-    check if value is less than max_value or blank
-    If blank value check is not needed, use built-in 'less_than'
-
-    Args:
-        value (str): parsed value
-        max_value(str): maximum value
-        accept_blank (bool): accept blank value
-    Returns:
-        bool: true if blank or value is less than max
-    """
-    check_result = value < max_value
-    return _check_blank_(value, check_result, accept_blank)
+    return comparison_helper(value, "<", max_value, accept_blank)
 
 
 def has_valid_format(value: str, regex: str, accept_blank: bool = False) -> bool:

--- a/src/regtech_data_validator/check_functions.py
+++ b/src/regtech_data_validator/check_functions.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 from typing import Dict
 
 import pandas as pd
+import operator
 
 
 def _check_blank_(value: str, check_result: bool, accept_blank: bool = False) -> bool:
@@ -39,19 +40,12 @@ def _check_blank_(value: str, check_result: bool, accept_blank: bool = False) ->
         return check_result
 
 
-def comparison_helper(value: str, sign: str, limit: str, accept_blank: bool = False) -> bool:
-    """
-    Used to first check if blank values are acceptable and returns corresponding boolean result.
-    Then, if actual value exists, uses python eval() to convert string to numerical values
-    and then evals again to use the passed in sign to compare the value to the limit.  This
-    ensures accurate comparison checks.
-    """
-    if accept_blank and not value.strip():
-        return True
-    elif not accept_blank and not value.strip():
+def comparison_helper(value: str, limit: str, accept_blank: bool, operand) -> bool:
+    if not value.strip() and not accept_blank:
         return False
-    else:
-        return (bool)(eval(f"eval(value) {sign} eval(limit)"))
+    elif not value.strip() and accept_blank:
+        return True
+    return operand(float(value), float(limit))
 
 
 def begins_with_same_lei(ulis: pd.Series) -> bool:
@@ -467,15 +461,15 @@ def is_valid_code(ct_value: str, accept_blank: bool = False, codes: dict = {}) -
 
 
 def is_greater_than_or_equal_to(value: str, min_value: str, accept_blank: bool = False) -> bool:
-    return comparison_helper(value, ">=", min_value, accept_blank)
+    return comparison_helper(value, min_value, accept_blank, operator.ge)
 
 
 def is_greater_than(value: str, min_value: str, accept_blank: bool = False) -> bool:
-    return comparison_helper(value, ">", min_value, accept_blank)
+    return comparison_helper(value, min_value, accept_blank, operator.gt)
 
 
 def is_less_than(value: str, max_value: str, accept_blank: bool = False) -> bool:
-    return comparison_helper(value, "<", max_value, accept_blank)
+    return comparison_helper(value, max_value, accept_blank, operator.lt)
 
 
 def has_valid_format(value: str, regex: str, accept_blank: bool = False) -> bool:

--- a/tests/test_check_functions.py
+++ b/tests/test_check_functions.py
@@ -516,6 +516,11 @@ class TestIsGreaterThan:
         assert is_greater_than("", "2") is False
         assert is_greater_than(" ", "2") is False
 
+    def test_with_larger_numbers(self):
+        assert is_greater_than("715", "1200") is False
+        assert is_greater_than("1240", "1200") is True
+        assert is_greater_than("125.9", "130") is False
+
 
 class TestIsGreaterThanOrEqualTo:
     def test_with_greater_min_value(self):
@@ -535,6 +540,12 @@ class TestIsGreaterThanOrEqualTo:
         assert is_greater_than_or_equal_to("", "2") is False
         assert is_greater_than_or_equal_to(" ", "2") is False
 
+    def test_with_larger_numbers(self):
+        assert is_greater_than_or_equal_to("715", "1200") is False
+        assert is_greater_than_or_equal_to("1240", "1200") is True
+        assert is_greater_than_or_equal_to("1200", "1200") is True
+        assert is_greater_than_or_equal_to("125.9", "130") is False
+
 
 class TestIsLessThan:
     def test_with_greater_max_value(self):
@@ -553,6 +564,11 @@ class TestIsLessThan:
     def test_with_invalid_blank_space(self):
         assert is_less_than("", "1") is False
         assert is_less_than(" ", "1") is False
+
+    def test_with_larger_numbers(self):
+        assert is_less_than("715", "1200") is True
+        assert is_less_than("1240", "1200") is False
+        assert is_less_than("125.9", "130") is True
 
 
 class TestHasValidFormat:


### PR DESCRIPTION
Closes #146 

Turns out our is_less_than, is_greater_than and is_greater_than_or_equals all had the same issue.  So I created a comparison_helper function that uses python eval() to convert the value to its type (so we're not beholden to int, float, etc in the functions) and then uses eval again with the passed in comparison sign to evaluate the value and the limit.

Also beefed up the pytests for all three functions to use values that would actually cause the error.  Simple strings like "1" and "2" won't cut it.