### PR TITLE
151 change formatters and groupby fields to maintain order

### DIFF
--- a/src/regtech_data_validator/create_schemas.py
+++ b/src/regtech_data_validator/create_schemas.py
@@ -11,8 +11,6 @@ from regtech_data_validator.schema_template import get_template
 
 from enum import StrEnum
 
-from collections import OrderedDict
-
 
 class ValidationPhase(StrEnum):
     SYNTACTICAL = "Syntactical"
@@ -51,7 +49,7 @@ def _get_check_fields(check: Check, primary_column: str) -> list[str]:
     if check.groupby:
         field_list += check.groupby
     # remove possible dupes but maintain order
-    field_list = list(OrderedDict.fromkeys(field_list))
+    field_list = list(dict.fromkeys(field_list))
     return field_list
 
 

--- a/src/regtech_data_validator/data_formatters.py
+++ b/src/regtech_data_validator/data_formatters.py
@@ -23,7 +23,7 @@ def df_to_download(df: pd.DataFrame) -> str:
                 row_data.append(f"\"{v_head['validation_desc']}\"")
 
                 current_count = 0
-                for field_name, field_df in rec_df.groupby(by='field_name'):
+                for field_name, field_df in rec_df.groupby(by='field_name', sort=False):
                     field_data = field_df.iloc[0]
                     row_data.append(field_name)
                     row_data.append(field_data['field_value'])
@@ -97,7 +97,7 @@ def df_to_json(df: pd.DataFrame) -> str:
             record_json = {'record_no': int(rec_idx), 'uid': rec['uid'], 'fields': []}
             finding_json['records'].append(record_json)
 
-            for field_idx, field_df in rec_df.groupby(by='field_name'):
+            for field_idx, field_df in rec_df.groupby(by='field_name', sort=False):
                 field_head = field_df.iloc[0]
                 record_json['fields'].append({'name': field_idx, 'value': field_head.at['field_value']})
     json_str = json.dumps(findings_json, indent=4)

--- a/src/regtech_data_validator/phase_validations.py
+++ b/src/regtech_data_validator/phase_validations.py
@@ -38,20 +38,6 @@ def get_phase_1_and_2_validations_for_lei(context: dict[str, str] | None = None)
     return {
         "uid": {
             "phase_1": [
-                SBLCheck(
-                    is_unique_column,
-                    id="E3000",
-                    fig_link=global_data.fig_base_url + "#4.3.1",
-                    name="uid.duplicates_in_dataset",
-                    description=dedent(
-                        """\
-                        * Any 'unique identifier' may **not** be used in more than one 
-                        record within a small business lending application register.
-                    """
-                    ),
-                    severity=Severity.ERROR,
-                    groupby="uid",
-                ),
                 SBLCheck.str_length(
                     21,
                     45,
@@ -84,6 +70,20 @@ def get_phase_1_and_2_validations_for_lei(context: dict[str, str] | None = None)
                 ),
             ],
             "phase_2": [
+                SBLCheck(
+                    is_unique_column,
+                    id="E3000",
+                    fig_link=global_data.fig_base_url + "#4.3.1",
+                    name="uid.duplicates_in_dataset",
+                    description=dedent(
+                        """\
+                        * Any 'unique identifier' may **not** be used in more than one 
+                        record within a small business lending application register.
+                    """
+                    ),
+                    severity=Severity.ERROR,
+                    groupby="uid",
+                ),
                 SBLCheck(
                     string_contains,
                     id="W0003",


### PR DESCRIPTION
Closes #151 

Updated areas of code called out in the story.

Attached a before and after csv to show what was happening.  We don't have any pytests that are this verbose to find those errors/warnings that were causing the reordering.  Can add those if desired.
[logical_errors_example.csv](https://github.com/cfpb/regtech-data-validator/files/14961898/logical_errors_example.csv)
[old_order_logical_errors_example.csv](https://github.com/cfpb/regtech-data-validator/files/14961899/old_order_logical_errors_example.csv)

Notice the ordering of the fieds for E2014 and W2035.  The old format had them reordered lexicographically, whereas the new order maintains what is in the FIG and in the groupby order of the Checks.