### PR TITLE
Changed to use pivot tables in the download formatter

### DIFF
--- a/src/regtech_data_validator/create_schemas.py
+++ b/src/regtech_data_validator/create_schemas.py
@@ -185,10 +185,7 @@ def validate_phases(df: pd.DataFrame, context: dict[str, str] | None = None) -> 
     p1_is_valid, p1_findings = validate(get_phase_1_schema_for_lei(context), df)
 
     if not p1_is_valid:
-        p1_findings.insert(1, "validation_phase", ValidationPhase.SYNTACTICAL.value, True)
         return p1_is_valid, p1_findings, ValidationPhase.SYNTACTICAL.value
 
     p2_is_valid, p2_findings = validate(get_phase_2_schema_for_lei(context), df)
-    if not p2_is_valid:
-        p2_findings.insert(1, "validation_phase", ValidationPhase.LOGICAL.value, True)
     return p2_is_valid, p2_findings, ValidationPhase.LOGICAL.value

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -132,13 +132,13 @@ class TestOutputFormat:
     def test_download_csv(self):
         expected_output = dedent(
             """
-            validation_type,validation_id,validation_name,row,unique_identifier,fig_link,validation_description,field_1,value_1
-            Error,E3000,uid.duplicates_in_dataset,2,12345678901234567890,https://www.consumerfinance.gov/data-research/small-business-lending/filing-instructions-guide/2024-guide/#4.3.1,"Any 'unique identifier' may not be used in mor...",uid,12345678901234567890
-            Error,E3000,uid.duplicates_in_dataset,3,12345678901234567890,https://www.consumerfinance.gov/data-research/small-business-lending/filing-instructions-guide/2024-guide/#4.3.1,"Any 'unique identifier' may not be used in mor...",uid,12345678901234567890
+            "validation_type","validation_id","validation_name","row","unique_identifier","fig_link","validation_description","field_1","value_1"
+            "Error","E3000","uid.duplicates_in_dataset",2,"12345678901234567890","https://www.consumerfinance.gov/data-research/small-business-lending/filing-instructions-guide/2024-guide/#4.3.1","Any 'unique identifier' may not be used in mor...","uid","12345678901234567890"
+            "Error","E3000","uid.duplicates_in_dataset",3,"12345678901234567890","https://www.consumerfinance.gov/data-research/small-business-lending/filing-instructions-guide/2024-guide/#4.3.1","Any 'unique identifier' may not be used in mor...","uid","12345678901234567890"
             """
         ).strip('\n')
         actual_output = df_to_download(self.input_df)
-        assert actual_output == expected_output
+        assert actual_output.strip() == expected_output
 
     def test_empty_download_csv(self):
         expected_output = dedent(

--- a/tests/test_schema_functions.py
+++ b/tests/test_schema_functions.py
@@ -215,7 +215,6 @@ class TestValidatePhases:
         # should only return phase 1 validation result since phase1 failed
         assert not is_valid
 
-        assert [ValidationPhase.SYNTACTICAL.value] == findings_df["validation_phase"].unique().tolist()
         assert validation_phase == ValidationPhase.SYNTACTICAL.value
         assert len(findings_df) == 1
 
@@ -233,7 +232,6 @@ class TestValidatePhases:
         # since the data passed phase 1 validations
         # this should return phase 2 validations
         assert not is_valid
-        assert [ValidationPhase.LOGICAL.value] == findings_df["validation_phase"].unique().tolist()
         assert validation_phase == ValidationPhase.LOGICAL.value
         assert len(findings_df.index.unique()) == 4
 


### PR DESCRIPTION
Closes #166 

Changed the df_to_download to use pivot tables to generate the csv.  This greatly improves the processing time of this function to just a few seconds for very large files, and consistently stays there as size increases.

Also used QUOTE_NONNUMERIC instead of specifically escaping just the description column.