### PR TITLE
Updated check function to us in/not in

### DIFF
--- a/src/regtech_data_validator/check_functions.py
+++ b/src/regtech_data_validator/check_functions.py
@@ -336,9 +336,9 @@ def _has_valid_enum_pair_validation_helper(
 ) -> pd.Series:
     result = pd.Series(index=series.index, name=series.name, data=True)
     if condition:
-        result = series == condition_value
+        result = series.str.split(';').apply(lambda x: condition_value in x)
     else:
-        result = series != condition_value
+        result = series.str.split(';').apply(lambda x: condition_value not in x)
     return result
 
 


### PR DESCRIPTION
Closes #241 

This was tested using the attached sblar.  Prior to the fix, entries 1 and 4-8 should have thrown E2011 but were not (with action_taken equaling 3, denial_reasons cannot contain 999 but they obviously do). With this fix, E2011 is now thrown for those entries, and all the previous correctly thrown errors using the has_valid_enum_pair check function are still thrown.
[all_logic_errors.csv](https://github.com/user-attachments/files/16515018/all_logic_errors.csv)
