### PR TITLE
Updated to remove writing of download report, returns byte data

### DIFF
--- a/src/regtech_data_validator/cli.py
+++ b/src/regtech_data_validator/cli.py
@@ -108,7 +108,7 @@ def validate(
         case OutputFormat.TABLE:
             print(df_to_table(final_df))
         case OutputFormat.DOWNLOAD:
-            df_to_download(final_df)
+            print(df_to_download(final_df))
         case _:
             raise ValueError(f'output format "{output}" not supported')
 

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -1,9 +1,6 @@
 import polars as pl
 import ujson
 
-import tempfile
-from pathlib import Path
-
 from regtech_data_validator import global_data
 from regtech_data_validator.data_formatters import df_to_csv, df_to_str, df_to_json, df_to_table, df_to_download
 from regtech_data_validator.validation_results import ValidationPhase
@@ -254,14 +251,8 @@ class TestOutputFormat:
             """
         ).strip('\n')
 
-        gf = tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.csv')
-        temp_path = Path(gf.name)
-        df_to_download(self.findings_df, str(temp_path.resolve()))
-        with open(temp_path, 'r') as output:
-            actual_output = output.read()
-        print(f"{actual_output}")
+        actual_output = df_to_download(self.findings_df).decode('utf-8')
         assert actual_output.strip() == expected_output
-        temp_path.unlink()
 
     def test_empty_download_csv(self):
         expected_output = dedent(
@@ -270,10 +261,5 @@ class TestOutputFormat:
             """
         ).strip('\n')
 
-        gf = tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.csv')
-        temp_path = Path(gf.name)
-        df_to_download(pl.DataFrame(), str(temp_path.resolve()))
-        with open(temp_path, 'r') as output:
-            actual_output = output.read()
+        actual_output = df_to_download(pl.DataFrame()).decode('utf-8')
         assert actual_output.strip() == expected_output
-        temp_path.unlink()


### PR DESCRIPTION
Closes #269 

Changed df_to_download to return the byte object of the report data (which the filing api can then use directly to store to S3).  Updated pytests to reflect change